### PR TITLE
US.02 / T.05 Implement user creation logic

### DIFF
--- a/backend/src/http/controllers/users.docs.ts
+++ b/backend/src/http/controllers/users.docs.ts
@@ -1,10 +1,16 @@
-import { Body, Controller, Get, Path, Put, Route, SuccessResponse, Response, Tags } from "tsoa";
-import { User, UpdateUserRequest } from "@api/users";
+import { Body, Controller, Post, Get, Path, Put, Route, SuccessResponse, Response, Tags } from "tsoa";
+import { User, UpdateUserRequest, CreateUserRequest } from "@api/users";
 import { HttpStatus } from "@api/helpers/http";
 
 @Route("api/users")
 @Tags("Users")
 class UsersDocs extends Controller {
+  @Post()
+  @SuccessResponse(HttpStatus.Created, "User Created")
+  async createUser(@Body() body: CreateUserRequest): Promise<User> {
+    return null as any;
+  }
+
   @Get("{id}")
   @Response(HttpStatus.NotFound, "User not found")
   async getUser(@Path() id: number): Promise<User> {

--- a/backend/src/http/controllers/users.ts
+++ b/backend/src/http/controllers/users.ts
@@ -1,7 +1,17 @@
 import type { RequestHandler } from "express";
 import { InvalidParamsError } from "@api/helpers/errors";
 import { HttpStatus } from "@api/helpers/http";
-import type { IUsersService, UpdateUserRequest } from "@api/users";
+import type { CreateUserRequest, IUsersService, UpdateUserRequest } from "@api/users";
+
+export function HandleCreateUser(service: IUsersService): RequestHandler {
+  return async (req, res) => {
+    const userReq = req.body as CreateUserRequest;
+
+    const user = await service.Create(userReq);
+
+    res.status(HttpStatus.Created).json(user);
+  };
+}
 
 export function HandleUpdateUser(service: IUsersService): RequestHandler {
   return async (req, res) => {

--- a/backend/src/http/routes.ts
+++ b/backend/src/http/routes.ts
@@ -1,7 +1,7 @@
 import { Router } from "express";
 import swaggerUi from "swagger-ui-express";
 import type { Core } from "@api/core";
-import { HandleGetUser, HandleUpdateUser } from "@api/http/controllers/users";
+import { HandleCreateUser, HandleGetUser, HandleUpdateUser } from "@api/http/controllers/users";
 import spec from "@api/http/docs/swagger.json"; //  this is generated automatically after running `npm run dev` or `npm run build`
 
 export function Routes(core: Core) {
@@ -22,7 +22,7 @@ export function Routes(core: Core) {
   // Users routes
   router.get("/users/:id", HandleGetUser(core.UsersService));
   router.put("/users/:id", HandleUpdateUser(core.UsersService));
-
+  router.post("/users", HandleCreateUser(core.UsersService));
   // Add more routes here
   // ...
 

--- a/backend/src/users/postgres_repository.ts
+++ b/backend/src/users/postgres_repository.ts
@@ -5,9 +5,28 @@ import type { IUsersRepository, User } from "./users";
 export class UsersRepository implements IUsersRepository {
   constructor(private db: NeonQueryFunction<false, true>) {}
 
-  // TODO: implement
   async Create(user: User): Promise<User> {
-    throw new Error("Method not implemented.");
+    // both "dietPreferences" and "allergies" are not entered by user
+    const result = await this.db`
+      INSERT INTO users (
+        "firstName",
+        "lastName",
+        "email",
+        "dietPreferences",
+        "allergies"
+      )
+      VALUES (
+        ${user.firstName},
+        ${user.lastName},
+        ${user.email},
+        ${user.dietPreferences},
+        ${user.allergies}
+      )
+      RETURNING *
+    `;
+
+    
+    return result.rows[0] as User;
   }
 
   async Update(userID: number, user: User): Promise<void> {

--- a/backend/src/users/users.ts
+++ b/backend/src/users/users.ts
@@ -9,6 +9,14 @@ export type User = {
   allergies: string[];
 };
 
+const createUserRequestSchema = z.object({
+  firstName: z.string().min(1),
+  lastName: z.string().min(1),
+  email: z.email(),
+});
+
+export type CreateUserRequest = z.infer<typeof createUserRequestSchema>;
+
 const updateUserRequestSchema = z.object({
   firstName: z.string().min(1),
   lastName: z.string().min(1),
@@ -19,8 +27,7 @@ const updateUserRequestSchema = z.object({
 export type UpdateUserRequest = z.infer<typeof updateUserRequestSchema>;
 
 export interface IUsersService {
-  // TODO: user creation
-  Create(user: User): Promise<User>;
+  Create(request: CreateUserRequest): Promise<User>;
   Update(userID: number, request: UpdateUserRequest): Promise<void>;
   Get(userID: number): Promise<User>;
 }
@@ -34,8 +41,20 @@ export interface IUsersRepository {
 export class UsersService implements IUsersService {
   constructor(private repository: IUsersRepository) {}
 
-  // TODO: implement user creation
-  Create(user: User): Promise<User> {
+  async Create(req: CreateUserRequest): Promise<User> {
+    const validation = createUserRequestSchema.safeParse(req);
+    if (validation.error) {
+      throw InvalidParamsError.FromZodError(validation.error);
+    }
+    
+    const user: User = {
+      firstName: req.firstName,
+      lastName: req.lastName,
+      email: req.email,
+      dietPreferences: [],
+      allergies: [],
+    }
+
     return this.repository.Create(user);
   }
 


### PR DESCRIPTION
Fix for #21, that PR got accidentally merged into a feature branch rather than `main`

---
- Implemented user account creation
- Added API validation

I used the logic that the allergies and diet preferences are elements not entered during profile creation (only when managing profile). Let me know going forward if we keep it this way, then we could let frontend know.

Also if possible maybe Wednesday or some other point I need help with setting up swagger on my end, first time using it.